### PR TITLE
Fixed mat, lb and ub pass-by-reference bug

### DIFF
--- a/solver.sage
+++ b/solver.sage
@@ -11,7 +11,8 @@ def Babai_CVP(mat, target):
 	return target - diff
 
 
-def solve(mat, lb, ub, weight = None):
+def solve(M, lbounds, ubounds, weight = None):
+	mat, lb, ub = copy(M), copy(lbounds), copy(ubounds)
 	num_var  = mat.nrows()
 	num_ineq = mat.ncols()
 


### PR DESCRIPTION
- `solver.sage` currently modifies the input matrix and the lists of the CVP bounds, which leads to bugs when reusing them somewhere else in the script.

Issue fixed by creating a copy of the input parameters instead of the actual input parameters.